### PR TITLE
Update references to .editor to use atom-text-editor.

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,18 +1,18 @@
 /* General Style */
-.editor, .editor .gutter {
+atom-text-editor, .atom-text-editor .gutter {
   background-color: #222222;
   color: #f8f8f2;
 }
 
-.editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor {
   border-color: #f8f8f0;
 }
 
-.editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: #444444;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
   background-color: #333333;
 }
 
@@ -122,9 +122,9 @@
 }
 
 /* Git status gutter */
-.editor .gutter .line-number.git-line-added,
-.editor .gutter .line-number.git-line-modified,
-.editor .gutter .line-number.git-line-removed {
+atom-text-editor .gutter .line-number.git-line-added,
+atom-text-editor .gutter .line-number.git-line-modified,
+atom-text-editor .gutter .line-number.git-line-removed {
   border-left-width: 4px;
 }
 

--- a/index.less
+++ b/index.less
@@ -1,18 +1,22 @@
 /* General Style */
-atom-text-editor, .atom-text-editor .gutter {
+atom-text-editor, atom-text-editor .gutter,
+:host, :host .gutter {
   background-color: #222222;
   color: #f8f8f2;
 }
 
-atom-text-editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor,
+:host.is-focused .cursor  {
   border-color: #f8f8f0;
 }
 
-atom-text-editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region,
+:host.is-focused .selection .region {
   background-color: #444444;
 }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,
+:host.is-focused .line-number.cursor-line-no-selection, :host.is-focused .line.cursor-line {
   background-color: #333333;
 }
 
@@ -124,7 +128,10 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
 /* Git status gutter */
 atom-text-editor .gutter .line-number.git-line-added,
 atom-text-editor .gutter .line-number.git-line-modified,
-atom-text-editor .gutter .line-number.git-line-removed {
+atom-text-editor .gutter .line-number.git-line-removed,
+:host .gutter .line-number.git-line-added,
+:host .gutter .line-number.git-line-modified,
+:host .gutter .line-number.git-line-removed {
   border-left-width: 4px;
 }
 


### PR DESCRIPTION
This adds support for using the shadow DOM and should be faster. See #2, #3, #4, #5.

@swest, @case does this look right?
