### PR TITLE
fix issue where highlighting text was not colorised

### DIFF
--- a/index.less
+++ b/index.less
@@ -20,6 +20,10 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   background-color: #333333;
 }
 
+atom-text-editor::shadow .selection .region {
+  background-color: rgba(255,255,255,0.4);
+}
+
 .comment {
   color: #75715e;
 }


### PR DESCRIPTION
I noticed an issue propably because of version 1.0+ of Atom the code for highlighting text changed a bit

the issue was that highlighting text had no color thus what you highlight was not clearly visible.

Added a white highlighting color with low opacity.
